### PR TITLE
fixing jquery selector for smooth scroll

### DIFF
--- a/assets/javascript/theme.js
+++ b/assets/javascript/theme.js
@@ -61,7 +61,7 @@ $(document).ready(function () {
     /**
      * Use smoothScroll for links that navigate inside the same page
      */
-    $('a[href*="#"]:not([href="#"]), a.inpage-navigation[href*="#"]').on('click', function (event) {
+    $('a[href^="#"]:not([href="#"]), a.inpage-navigation[href*="#"]').on('click', function (event) {
         event.preventDefault();
         smoothScroll($(this.hash));
     });


### PR DESCRIPTION
fixing jquery selector for smooth scroll links to not select external urls with hashtag. Tested locally

### Description
just changed ```a[href^="#"]``` to select for smoothscrolling links that starts with hashtag

### Motivation and Context
fixing issue for external links with hashtag

### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)

### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
* [x] My code follows the code style of this project.
* [ ] I have updated the documentation accordingly.
