### PR TITLE
Publish JiraAgilePS module and docs entry points

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -36,6 +36,9 @@
       groups:
         - Commands
         - Classes
+    - name: JiraAgilePS
+      path: docs/JiraAgilePS
+      listChilds: true
     # - name: HipChatPS
     #   path: docs/HipChatPS
     - name: JiraPS

--- a/docs/JiraAgilePS/index.md
+++ b/docs/JiraAgilePS/index.md
@@ -1,0 +1,21 @@
+---
+layout: documentation
+title: JiraAgilePS
+permalink: /docs/JiraAgilePS/
+---
+# JiraAgilePS
+
+JiraAgilePS extends JiraPS with Jira Agile functionality.
+
+If you are exploring what it can do, start here:
+
+1. Read the module overview: [/module/JiraAgilePS/](/module/JiraAgilePS/).
+2. Open the source and usage notes: <https://github.com/AtlassianPS/JiraAgilePS>.
+3. Discover commands in your shell:
+
+```powershell
+Get-Command -Module JiraAgilePS
+Get-Help Get-JiraAgileBoard -Full
+```
+
+As we publish richer command reference pages, they will appear in this section.


### PR DESCRIPTION
Adds the JiraAgilePS submodule back into published site content, creates /docs/JiraAgilePS/, and wires JiraAgilePS into documentation navigation to close the publishing gap.