### PR TITLE
Clarify website copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017 AtlassianPS
+Copyright (c) 2017 AtlassianPS contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,7 +6,7 @@
             </div>
             <div class="row">
                 <div class="col-12">
-                    Copyright © {{ site.time | date: "%Y" }} AtlassianPS
+                    Copyright © 2017 AtlassianPS contributors
                 </div>
             </div>
             <div class="row d-print-none">


### PR DESCRIPTION
## Summary

- attribute the current website to `AtlassianPS contributors`
- use the site's 2017 origin year in both the MIT license and footer
- leave all bundled third-party copyright and license notices intact

The deleted predecessor draft does not survive in the current site, so this does not add Damien Sorel or Tomas Deceuninck to the current first-party notice. This changes attribution metadata, not the MIT license terms.

## Validation

- `bundle exec jekyll build --baseurl ""`
- `git diff --check`
